### PR TITLE
Małe czyszczenie bo się nie syntezuje

### DIFF
--- a/soc/ps2.v
+++ b/soc/ps2.v
@@ -13,7 +13,6 @@ reg irq;
 
 initial irq = 1'b0;
 initial scancode = 8'hFF;
-reg [3:0] bit = 4'b0;
 reg [10:0] code_shift;
  
 wire db_clk;

--- a/soc/soc_rom.v
+++ b/soc/soc_rom.v
@@ -8,7 +8,7 @@ module soc_rom (
 reg [31:0] instr [127:0];
 
 initial begin
-    $readmemh("/home/piotro/pcpu2/soc/bootloader.hex", instr);
+    $readmemh("bootloader.hex", instr);
 end
 
 always @* begin


### PR DESCRIPTION
This pull request includes changes to the PS2 and ROM modules to clean up the code and improve file path management.

Code cleanup and improvements:

* [`soc/ps2.v`](diffhunk://#diff-a15202b5f21724b9b73e5f8b7ebbe76e8c0f0ffaa926e5ee279c9e734e350b52L16): Removed the unnecessary `bit` register definition.

File path management:

* [`soc/soc_rom.v`](diffhunk://#diff-a299e398fbbc8014ca904888397c66af9e41e18c3f51c754ee94e64e1f6ab686L11-R11): Updated the bootloader file path in the `$readmemh` call to use a relative path instead of an absolute path.